### PR TITLE
fixed bug which did not allow to query ONLY read items

### DIFF
--- a/src/NotificationHelper.php
+++ b/src/NotificationHelper.php
@@ -47,9 +47,9 @@ class NotificationHelper
     public static function getNotificationsTo($type, $id, $params = [])
     {
         $defaults = [
-            'unread'   => true,
+            'unread' => true,
             'category' => null,
-            'per_page'  => 10,
+            'per_page' => 10,
         ];
 
         $params = array_merge($defaults, $params);
@@ -67,8 +67,8 @@ class NotificationHelper
             $notificationQuery->where('notification_category_id', $categoryObj->id);
         }
 
-        if ($params['unread']) {
-            $notificationQuery->where('read', 0);
+        if (isset($params['unread'])) {
+          $notificationQuery->where('read', !$params['unread']);
         }
 
         $notificationQuery->with(['notification_message', 'notification_category'])


### PR DESCRIPTION
The original `if ($params['unread'])` statement meant that if `$params['unread']` was set to `false` (ie. someone asking for _read_ notifications), no condition would be added to the query, and the end-user would get _all_ notifications (both read and unread). The new `isset()` condition addresses that issue.

It may also be worthwhile to remove the default `unread` parameter. That would allow the end-user to get all notifications (by not specifying it), and force them to be explicit if they only want read or unread.
